### PR TITLE
fix: AMP-57521-EventOptions-add-struct-type

### DIFF
--- a/amplitude/event.go
+++ b/amplitude/event.go
@@ -3,40 +3,40 @@ package amplitude
 import "time"
 
 type EventOptions struct {
-	UserID             string `json:"user_id"`
-	DeviceID           string `json:"device_id"`
-	Time               int64  `json:"time,omitempty"`
-	InsertID           string `json:"insert_id,omitempty"`
-	Library            string `json:"library,omitempty"`
-	LocationLat        float64
-	LocationLng        float64
-	AppVersion         string
-	VersionName        string
-	Platform           string
-	OSName             string
-	OSVersion          string
-	DeviceBrand        string
-	DeviceManufacturer string
-	DeviceModel        string
-	Carrier            string
-	Country            string
-	Region             string
-	City               string
-	DMA                string
-	IDFA               string
-	IDFV               string
-	ADID               string
-	AndroidID          string
-	Language           string
-	IP                 string
-	Price              float64
-	Quantity           int
-	Revenue            float64
-	ProductID          string
-	RevenueType        string
-	EventID            int
-	SessionID          int
-	PartnerId          string
+	UserID             string  `json:"user_id"`
+	DeviceID           string  `json:"device_id"`
+	Time               int64   `json:"time,omitempty"`
+	InsertID           string  `json:"insert_id,omitempty"`
+	Library            string  `json:"library,omitempty"`
+	LocationLat        float64 `json:"location_lat,omitempty"`
+	LocationLng        float64 `json:"location_lng,omitempty"`
+	AppVersion         string  `json:"app_version,omitempty"`
+	VersionName        string  `json:"version_name,omitempty"`
+	Platform           string  `json:"platform,omitempty"`
+	OSName             string  `json:"os_name,omitempty"`
+	OSVersion          string  `json:"os_version,omitempty"`
+	DeviceBrand        string  `json:"device_brand,omitempty"`
+	DeviceManufacturer string  `json:"device_manufacturer,omitempty"`
+	DeviceModel        string  `json:"device_model,omitempty"`
+	Carrier            string  `json:"carrier,omitempty"`
+	Country            string  `json:"country,omitempty"`
+	Region             string  `json:"region,omitempty"`
+	City               string  `json:"city,omitempty"`
+	DMA                string  `json:"dma,omitempty"`
+	IDFA               string  `json:"idfa,omitempty"`
+	IDFV               string  `json:"idfv,omitempty"`
+	ADID               string  `json:"adid,omitempty"`
+	AndroidID          string  `json:"android_id,omitempty"`
+	Language           string  `json:"language,omitempty"`
+	IP                 string  `json:"ip,omitempty"`
+	Price              float64 `json:"price,omitempty"`
+	Quantity           int     `json:"quantity,omitempty"`
+	Revenue            float64 `json:"revenue,omitempty"`
+	ProductID          string  `json:"productId,omitempty"`
+	RevenueType        string  `json:"revenueType,omitempty"`
+	EventID            int     `json:"event_id,omitempty"`
+	SessionID          int     `json:"session_id,omitempty"`
+	PartnerId          string  `json:"partner_id,omitempty"`
 	Plan               Plan
 }
 


### PR DESCRIPTION
<!---
Thanks for contributing to the Amplitude Go repository! 🎉

Please fill out the following sections to help us quickly review your pull request.
--->

### Summary
Add struct tags for fields in EventOptions for marshal 
- `productId` and `revenueType` are camel case, others are snake case by [http v2 api](https://www.docs.developers.amplitude.com/analytics/apis/http-v2-api/#upload-request-body-parameters)
- no partner id in http v2 api, so followed [python](https://github.com/amplitude/Amplitude-Python/blob/5f9f098f08cd5293ceb896e17435fc5249129adf/src/amplitude/event.py#L102)

<!-- What does the PR do? -->

### Checklist

* [ ] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-Go/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  <!-- Yes or no -->
