### PR TITLE
fix: AMP-56381-add-default-context-plugin

### DIFF
--- a/amplitude/client.go
+++ b/amplitude/client.go
@@ -16,7 +16,7 @@ type Client interface {
 func NewClient(config Config) Client {
 	client := &client{configuration: config}
 	client.Add(&AmplitudeDestinationPlugin{})
-	client.Add(&ContextPlugin{})
+	client.Add(NewContextPlugin())
 
 	return client
 }

--- a/examples/track_example/track_example.go
+++ b/examples/track_example/track_example.go
@@ -20,8 +20,6 @@ func main() {
 	// Config callback function (optional)
 	client := amplitude.NewClient(config)
 
-	client.Add(amplitude.NewContextPlugin())
-
 	// Create a BaseEvent instance
 	event := amplitude.Event{
 		EventOptions: amplitude.EventOptions{DeviceID: "go-device-id", UserID: "go-user-id"},


### PR DESCRIPTION
<!---
Thanks for contributing to the Amplitude Go repository! 🎉

Please fill out the following sections to help us quickly review your pull request.
--->

### Summary

Add default context plugin at `NewClient`
Delete adding default context at example 

<!-- What does the PR do? -->

### Checklist

* [ ] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-Go/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  <!-- Yes or no -->
