### PR TITLE
revert: update release workflow to include all commits for first release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -108,7 +108,7 @@ jobs:
           go build -o "$BINARY_NAME" -v
       - name: Release Notes
         run: |
-          touch ".github/RELEASE-TEMPLATE.md" && git log --pretty='format:* %h %s%n  * %an <%ae>' --no-merges >> ".github/RELEASE-TEMPLATE.md"
+          touch ".github/RELEASE-TEMPLATE.md" && git log $(git describe HEAD~ --tags --abbrev=0)..HEAD --pretty='format:* %h %s%n  * %an <%ae>' --no-merges >> ".github/RELEASE-TEMPLATE.md"
       - name: Release with Notes
         uses: softprops/action-gh-release@v1
         with:


### PR DESCRIPTION
### Summary

Reverts temporary change to accommodate first release workflow. The original script should work now given the next release should find the previous release tag.

### Checklist

* [ ] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-Go/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  <!-- Yes or no -->