### PR TITLE
chore: Release v0.0.2

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -10,5 +10,5 @@ Please fill out the following sections to help us quickly review your pull reque
 
 ### Checklist
 
-* [ ] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-Go/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
+* [ ] Does your PR title have the correct [title format](https://github.com/amplitude/analytics-go/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
 * Does your PR have a breaking change?:  <!-- Yes or no -->

--- a/amplitude/constants.go
+++ b/amplitude/constants.go
@@ -10,7 +10,7 @@ type IdentityOp string
 
 const (
 	SdkLibrary = "amplitude-go"
-	SdkVersion = "0.0.1"
+	SdkVersion = "0.0.2"
 
 	ServerZoneEU = "EU"
 	ServerZoneUS = "US"


### PR DESCRIPTION
<!---
Thanks for contributing to the Amplitude Go repository! 🎉

Please fill out the following sections to help us quickly review your pull request.
--->

### Summary
#### Release Go Alpha SDK `v0.0.2` 

Because this repo was renamed from `Amplitude-Go` to `analytics-go`
`go get github.com/amplitude/analytics-go` returns error:
```
module declares its path as: github.com/amplitude/Amplitude-Go
	       but was required as: github.com/amplitude/analytics-go
```
Bumping to another version to solve this problem 
<!-- What does the PR do? -->

### Checklist

* [ ] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-Go/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  <!-- Yes or no -->
