### PR TITLE
fix: Changes for ampli

### DIFF
--- a/amplitude/amplitude_plugin.go
+++ b/amplitude/amplitude_plugin.go
@@ -68,6 +68,7 @@ func (a *AmplitudePlugin) Execute(event *Event) {
 
 	a.mutex.Lock()
 	defer a.mutex.Unlock()
+
 	if a.messageChannel == nil {
 		return
 	}

--- a/amplitude/client.go
+++ b/amplitude/client.go
@@ -3,7 +3,7 @@ package amplitude
 type Client interface {
 	Track(event Event)
 	Identify(identify Identify, eventOptions EventOptions)
-	GroupIdentify(groupType string, groupName []string, identify Identify,
+	GroupIdentify(groupType string, groupName string, identify Identify,
 		eventOptions EventOptions)
 	Revenue(revenue Revenue, eventOptions EventOptions)
 	SetGroup(groupType string, groupName []string, eventOptions EventOptions)
@@ -47,7 +47,7 @@ func (a *client) Identify(identify Identify, eventOptions EventOptions) {
 }
 
 // GroupIdentify sends a group identify event to update group Properties.
-func (a *client) GroupIdentify(groupType string, groupName []string, identify Identify,
+func (a *client) GroupIdentify(groupType string, groupName string, identify Identify,
 	eventOptions EventOptions,
 ) {
 	if !identify.IsValid() {
@@ -56,7 +56,7 @@ func (a *client) GroupIdentify(groupType string, groupName []string, identify Id
 		groupIdentifyEvent := Event{
 			EventType:       GroupIdentifyEventType,
 			EventOptions:    eventOptions,
-			Groups:          map[string][]string{groupType: groupName},
+			Groups:          map[string][]string{groupType: []string{groupName}},
 			GroupProperties: identify.Properties,
 		}
 

--- a/amplitude/client.go
+++ b/amplitude/client.go
@@ -56,7 +56,7 @@ func (a *client) GroupIdentify(groupType string, groupName string, identify Iden
 		groupIdentifyEvent := Event{
 			EventType:       GroupIdentifyEventType,
 			EventOptions:    eventOptions,
-			Groups:          map[string][]string{groupType: []string{groupName}},
+			Groups:          map[string][]string{groupType: {groupName}},
 			GroupProperties: identify.Properties,
 		}
 

--- a/amplitude/config.go
+++ b/amplitude/config.go
@@ -56,7 +56,7 @@ func (c Config) IsEmpty() bool {
 		c.FlushQueueSize == 0 && c.FlushMaxRetries == 0 &&
 		c.Logger == nil && c.MinIDLength == 0 &&
 		c.Callback == nil && c.ServerZone == "" &&
-		c.UseBatch == false && c.Storage == nil &&
-		c.OptOut == false && c.Plan == Plan{} &&
+		!c.UseBatch && c.Storage == nil &&
+		!c.OptOut && c.Plan == Plan{} &&
 		c.ServerURL == ""
 }

--- a/amplitude/config.go
+++ b/amplitude/config.go
@@ -28,7 +28,7 @@ func NewConfig(apiKey string) Config {
 		FlushInterval:   DefaultFlushInterval,
 		FlushQueueSize:  DefaultFlushQueueSize,
 		FlushMaxRetries: DefaultFlushMaxRetries,
-		Logger:          newDefaultLogger(),
+		Logger:          NewDefaultLogger(),
 		MinIDLength:     DefaultMinIDLength,
 		Callback:        nil,
 		ServerZone:      ServerZoneUS,
@@ -49,4 +49,14 @@ func (c Config) IsValid() bool {
 
 func (c Config) IsMinIDLengthValid() bool {
 	return c.MinIDLength > 0
+}
+
+func (c Config) IsEmpty() bool {
+	return c.APIKey == "" && c.FlushInterval == 0 &&
+		c.FlushQueueSize == 0 && c.FlushMaxRetries == 0 &&
+		c.Logger == nil && c.MinIDLength == 0 &&
+		c.Callback == nil && c.ServerZone == "" &&
+		c.UseBatch == false && c.Storage == nil &&
+		c.OptOut == false && c.Plan == Plan{} &&
+		c.ServerURL == ""
 }

--- a/amplitude/http_client.go
+++ b/amplitude/http_client.go
@@ -9,7 +9,7 @@ import (
 
 type payload struct {
 	APIKey string   `json:"api_key"`
-	Events []*Event `json:"Events"`
+	Events []*Event `json:"events"`
 }
 
 type httpClient struct {

--- a/amplitude/logger.go
+++ b/amplitude/logger.go
@@ -6,34 +6,34 @@ import (
 )
 
 type Logger interface {
-	Debug(args ...interface{})
-	Info(args ...interface{})
-	Warn(args ...interface{})
-	Error(args ...interface{})
+	Debug(message string, args ...interface{})
+	Info(message string, args ...interface{})
+	Warn(message string, args ...interface{})
+	Error(message string, args ...interface{})
 }
 
 type stdLogger struct {
 	logger *log.Logger
 }
 
-func (l *stdLogger) Debug(args ...interface{}) {
-	l.logger.Printf("Debug: ", args...)
+func (l *stdLogger) Debug(message string, args ...interface{}) {
+	l.logger.Printf("Debug: "+message, args...)
 }
 
-func (l *stdLogger) Info(args ...interface{}) {
-	l.logger.Printf("Info: ", args...)
+func (l *stdLogger) Info(message string, args ...interface{}) {
+	l.logger.Printf("Info: "+message, args...)
 }
 
-func (l *stdLogger) Warn(args ...interface{}) {
-	l.logger.Printf("Warn: ", args...)
+func (l *stdLogger) Warn(message string, args ...interface{}) {
+	l.logger.Printf("Warn: "+message, args...)
 }
 
-func (l *stdLogger) Error(args ...interface{}) {
-	l.logger.Printf("Error: ", args...)
+func (l *stdLogger) Error(message string, args ...interface{}) {
+	l.logger.Printf("Error: "+message, args...)
 }
 
-func NewDefaultLogger() Logger {
+func newDefaultLogger() Logger {
 	return &stdLogger{logger: log.New(os.Stderr, "amplitude-analytics", log.LstdFlags)}
 }
 
-var globalLogger = NewDefaultLogger()
+var globalLogger = newDefaultLogger()

--- a/amplitude/logger.go
+++ b/amplitude/logger.go
@@ -6,34 +6,34 @@ import (
 )
 
 type Logger interface {
-	Debug(message string, args ...interface{})
-	Info(message string, args ...interface{})
-	Warn(message string, args ...interface{})
-	Error(message string, args ...interface{})
+	Debug(args ...interface{})
+	Info(args ...interface{})
+	Warn(args ...interface{})
+	Error(args ...interface{})
 }
 
 type stdLogger struct {
 	logger *log.Logger
 }
 
-func (l *stdLogger) Debug(message string, args ...interface{}) {
-	l.logger.Printf("Debug: "+message, args...)
+func (l *stdLogger) Debug(args ...interface{}) {
+	l.logger.Printf("Debug: ", args...)
 }
 
-func (l *stdLogger) Info(message string, args ...interface{}) {
-	l.logger.Printf("Info: "+message, args...)
+func (l *stdLogger) Info(args ...interface{}) {
+	l.logger.Printf("Info: ", args...)
 }
 
-func (l *stdLogger) Warn(message string, args ...interface{}) {
-	l.logger.Printf("Warn: "+message, args...)
+func (l *stdLogger) Warn(args ...interface{}) {
+	l.logger.Printf("Warn: ", args...)
 }
 
-func (l *stdLogger) Error(message string, args ...interface{}) {
-	l.logger.Printf("Error: "+message, args...)
+func (l *stdLogger) Error(args ...interface{}) {
+	l.logger.Printf("Error: ", args...)
 }
 
-func newDefaultLogger() Logger {
+func NewDefaultLogger() Logger {
 	return &stdLogger{logger: log.New(os.Stderr, "amplitude-analytics", log.LstdFlags)}
 }
 
-var globalLogger = newDefaultLogger()
+var globalLogger = NewDefaultLogger()

--- a/amplitude/logger.go
+++ b/amplitude/logger.go
@@ -32,8 +32,8 @@ func (l *stdLogger) Error(message string, args ...interface{}) {
 	l.logger.Printf("Error: "+message, args...)
 }
 
-func newDefaultLogger() Logger {
+func NewDefaultLogger() Logger {
 	return &stdLogger{logger: log.New(os.Stderr, "amplitude-analytics", log.LstdFlags)}
 }
 
-var globalLogger = newDefaultLogger()
+var globalLogger = NewDefaultLogger()

--- a/amplitude/plan.go
+++ b/amplitude/plan.go
@@ -1,3 +1,8 @@
 package amplitude
 
-type Plan struct{}
+type Plan struct {
+	Branch    string `json:"branch,omitempty"`
+	Source    string `json:"source,omitempty"`
+	Version   string `json:"version,omitempty"`
+	VersionID string `json:"versionId,omitempty"`
+}

--- a/examples/track_example/track_example.go
+++ b/examples/track_example/track_example.go
@@ -5,20 +5,12 @@ package main
 // Import amplitude package
 import (
 	"github.com/amplitude/analytics-go/amplitude"
-	"time"
 )
-
-// Define your callback function (optional)
-func callbackFunc(e string, code int, message string) {
-	println(e)
-	println(code, message)
-}
 
 func main() {
 
 	config := amplitude.NewConfig("your-api-key")
 
-	// Config callback function (optional)
 	client := amplitude.NewClient(config)
 
 	// Track a basic event
@@ -27,8 +19,6 @@ func main() {
 		EventOptions: amplitude.EventOptions{UserID: "user-id"},
 		EventType:    "Button Clicked",
 	}
-	// Set time of event
-	event.SetTime(time.Now())
 	client.Track(event)
 
 	// Track events with optional properties


### PR DESCRIPTION
<!---
Thanks for contributing to the Amplitude Go repository! 🎉

Please fill out the following sections to help us quickly review your pull request.
--->

### Summary
Changes for go ampli

1. `GroupIdentify` should only accept single group name 
2. Made `NewDefaultLogger()` to public, and created `IsEmpty()`, which are used in go ampli  
3. in payload, `events` should be lower cased. https://www.docs.developers.amplitude.com/analytics/apis/http-v2-api/?h=http#upload-request-body-parameters
4. Added plan property tags for marshal 
5. Deleted callback function in example, because callback function is not implemented right now

<!-- What does the PR do? -->

### Checklist

* [ ] Does your PR title have the correct [title format](https://github.com/amplitude/analytics-go/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  <!-- Yes or no -->
