### PR TITLE
fix: add UserID/DeviceID to Event struct

### DIFF
--- a/amplitude/client.go
+++ b/amplitude/client.go
@@ -65,6 +65,14 @@ func (c *client) Track(event Event) {
 		event.IngestionMetadata = c.config.IngestionMetadata
 	}
 
+	if event.EventOptions.UserID == "" && event.UserID != "" {
+		event.EventOptions.UserID = event.UserID
+	}
+
+	if event.EventOptions.DeviceID == "" && event.DeviceID != "" {
+		event.EventOptions.DeviceID = event.DeviceID
+	}
+
 	c.config.Logger.Debugf("Track event: \n\t%+v", event)
 	c.timeline.Process(&event)
 }

--- a/amplitude/types/event.go
+++ b/amplitude/types/event.go
@@ -7,6 +7,12 @@ type Event struct {
 	UserProperties  map[IdentityOp]map[string]interface{} `json:"user_properties,omitempty"`
 	Groups          map[string][]string                   `json:"groups,omitempty"`
 	GroupProperties map[IdentityOp]map[string]interface{} `json:"group_properties,omitempty"`
+
+	// UserID is a user identifier. The value is ignored if EventOptions.UserID is set.
+	UserID string `json:"-"`
+
+	// DeviceID is a device-specific identifier. The value is ignored if EventOptions.DeviceID is set.
+	DeviceID string `json:"-"`
 }
 
 func (e Event) Clone() Event {
@@ -17,6 +23,8 @@ func (e Event) Clone() Event {
 		UserProperties:  cloneIdentityProperties(e.UserProperties),
 		Groups:          cloneGroups(e.Groups),
 		GroupProperties: cloneIdentityProperties(e.GroupProperties),
+		UserID:          e.UserID,
+		DeviceID:        e.DeviceID,
 	}
 }
 

--- a/examples/identify_example/identify_example.go
+++ b/examples/identify_example/identify_example.go
@@ -27,8 +27,9 @@ func main() {
 	// Let's track another event
 	// Then you can see that user properties of this event has location set to LAX
 	event := amplitude.Event{
-		EventOptions: amplitude.EventOptions{DeviceID: "identify-device-id", UserID: "identify-user-id"},
-		EventType:    "identify-event-type",
+		EventType: "identify-event-type",
+		DeviceID:  "identify-device-id",
+		UserID:    "identify-user-id",
 	}
 	client.Track(event)
 

--- a/examples/track_example/track_example.go
+++ b/examples/track_example/track_example.go
@@ -16,18 +16,16 @@ func main() {
 	// Track a basic event
 	// One of UserID and DeviceID is required
 	event := amplitude.Event{
-		EventOptions: amplitude.EventOptions{UserID: "user-id"},
-		EventType:    "Button Clicked",
+		EventType: "Button Clicked",
+		UserID:    "user-id",
 	}
 	client.Track(event)
 
 	// Track events with optional properties
 	client.Track(amplitude.Event{
-		EventType: "type-of-event",
-		EventOptions: amplitude.EventOptions{
-			UserID:   "user-id",
-			DeviceID: "device-id",
-		},
+		EventType:       "type-of-event",
+		UserID:          "user-id",
+		DeviceID:        "device-id",
 		EventProperties: map[string]interface{}{"source": "notification"},
 	})
 


### PR DESCRIPTION
### Summary

Adds `EventID`/`DeviceID` to `Event` struct

### Checklist

* [x] Does your PR title have the correct [title format](https://github.com/amplitude/analytics-go/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  No
