### PR TITLE
fix: Identify event validation

### DIFF
--- a/amplitude/plugins/destination/amplitude_plugin.go
+++ b/amplitude/plugins/destination/amplitude_plugin.go
@@ -158,5 +158,6 @@ func (p *amplitudePlugin) Shutdown() {
 }
 
 func isValidEvent(event *types.Event) bool {
-	return event.EventType != "" && (event.UserID != "" || event.DeviceID != "")
+	return event.EventType != "" && (event.UserID != "" || event.DeviceID != "" ||
+		event.EventOptions.UserID != "" || event.EventOptions.DeviceID != "")
 }

--- a/amplitude/plugins/destination/amplitude_plugin_test.go
+++ b/amplitude/plugins/destination/amplitude_plugin_test.go
@@ -1,0 +1,55 @@
+package destination
+
+import (
+	"testing"
+
+	"github.com/amplitude/analytics-go/amplitude/types"
+	"github.com/stretchr/testify/assert"
+)
+
+func Test_isValidEvent(t *testing.T) {
+
+	validEvents := []types.Event{
+		{
+			EventType: "type",
+			UserID:    "id",
+		}, {
+			EventType: "type",
+			DeviceID:  "id",
+		}, {
+			EventType:    "type",
+			EventOptions: types.EventOptions{UserID: "id"},
+		}, {
+			EventType:    "type",
+			EventOptions: types.EventOptions{DeviceID: "id"},
+		}, {
+			EventType:    "type",
+			UserID:       "id",
+			EventOptions: types.EventOptions{UserID: "id"},
+		},
+	}
+
+	invalidEvents := []types.Event{
+		{},
+		{
+			UserID: "id",
+		},
+		{
+			DeviceID: "id",
+		},
+		{
+			EventOptions: types.EventOptions{UserID: "id"},
+		},
+		{
+			EventOptions: types.EventOptions{DeviceID: "id"},
+		},
+	}
+
+	for _, ev := range validEvents {
+		assert.True(t, isValidEvent(&ev))
+	}
+
+	for _, ev := range invalidEvents {
+		assert.False(t, isValidEvent(&ev))
+	}
+}


### PR DESCRIPTION
<!---
Thanks for contributing to the Amplitude Go repository! 🎉

Please fill out the following sections to help us quickly review your pull request.
--->

### Summary

https://github.com/amplitude/analytics-go/issues/47 — Cannot identify due to either UserID or DeviceID cannot be empty

<!-- What does the PR do? -->
Fixing the error in `client.Identiy()`, where it would create an `types.Event` without IDs:
```
identifyEvent := Event{
	EventType:      constants.IdentifyEventType,
	EventOptions:   eventOptions,
	UserProperties: identify.Properties,
}
```
causing the following error in run time:
```
amplitude_plugin.go:82: Error: Invalid event, EventType and either UserID or DeviceID cannot be empty: 
        &{EventType:$identify EventOptions:{UserID:4a616e2b-262a-4f24-948f-6599b50f1500 DeviceID:4a616e2b-262a-4f24-948f-6599b50f1500...
```

Fixing the problem by looking at the IDs in the `EventOptions`.

### Checklist

* [x] Does your PR title have the correct [title format](https://github.com/amplitude/analytics-go/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?: No <!-- Yes or no -->
* [x] Unit test added
