### PR TITLE
docs: fix go get command

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ This is Amplitude's latest and official version of Go SDK.
 Install analytics-go using go get:
 
 ```
-go get https://github.com/amplitude/analytics-go
+go get github.com/amplitude/analytics-go
 ```
 
 ## Usage


### PR DESCRIPTION
running `go get https://github.com/amplitude/analytics-go                                             1` (with https://) yields this error:
go: malformed module path "https:/github.com/amplitude/analytics-go": invalid char ':'

<!---
Thanks for contributing to the Amplitude Go repository! 🎉

Please fill out the following sections to help us quickly review your pull request.
--->

### Summary

<!-- What does the PR do? -->

### Checklist

* [X] Does your PR title have the correct [title format](https://github.com/amplitude/analytics-go/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  No