### PR TITLE
fix: clone map[string]interface{}

### DIFF
--- a/amplitude/types/event.go
+++ b/amplitude/types/event.go
@@ -141,7 +141,7 @@ func cloneUnknown(value interface{}) interface{} {
 		return cloneUnknowns(value)
 	case map[string]interface{}:
 		clone := make(map[string]interface{}, len(value))
-		for k, v := range clone {
+		for k, v := range value {
 			clone[k] = cloneUnknown(v)
 		}
 


### PR DESCRIPTION
<!---
Thanks for contributing to the Amplitude Go repository! 🎉

Please fill out the following sections to help us quickly review your pull request.
--->

### Summary

Fixes cloning a `map[string]interface{}` because currently it always returns an empty map.

### Checklist

* [x] Does your PR title have the correct [title format](https://github.com/amplitude/analytics-go/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  <!-- Yes or no -->
