### PR TITLE
fix: avoid lost of events on transmission failure

### DIFF
--- a/amplitude/plugins/destination/amplitude_plugin.go
+++ b/amplitude/plugins/destination/amplitude_plugin.go
@@ -192,6 +192,10 @@ func (p *amplitudePlugin) sendEventsFromStorage(wg *sync.WaitGroup) {
 			p.reduceChunkSize()
 		}
 
+		if len(result.EventsForRetry) > 0 {
+			p.storage.ReturnBack(result.EventsForRetry...)
+		}
+
 		executeCallback := p.config.ExecuteCallback
 		if executeCallback != nil && len(result.EventsForCallback) > 0 {
 			go func() {


### PR DESCRIPTION
<!---
Thanks for contributing to the Amplitude Go repository! 🎉

Please fill out the following sections to help us quickly review your pull request.
--->

### Summary

This PR addresses an issue with events get lost when marked for retry e.g. because of a transmission failure. If such events remain after processing, they will be returned back to storage using the ReturnBack method for later handling.

In our case we use a special storage which caches hundreds of events and delivers them once a day or if a number of events in the cache has reached. During our tests we reached the limits and the events which could not be delivered were lost in the end because of the missing handling of this case in the code. It should also be possible to reproduce this problem with the default storage by reaching the limits or cover it by a test which tests the case of a http status 429 returned by the API.

It's maybe a rare case but would be good it could be addressed to avoid the lost of any event.

### Checklist

* [X] Does your PR title have the correct [title format](https://github.com/amplitude/analytics-go/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?: No
