### PR TITLE
fix: should handle non-json format response

### DIFF
--- a/amplitude/plugins/destination/internal/amplitude_http_client.go
+++ b/amplitude/plugins/destination/internal/amplitude_http_client.go
@@ -109,7 +109,7 @@ func (c *amplitudeHTTPClient) Send(payload AmplitudePayload) AmplitudeResponse {
 	var amplitudeResponse AmplitudeResponse
 	if json.Valid(body) {
 		_ = json.Unmarshal(body, &amplitudeResponse)
-	}else{
+	} else {
 		c.logger.Debugf("HTTP response body is not valid JSON: %s", string(body))
 		amplitudeResponse.Code = response.StatusCode
 	}

--- a/amplitude/plugins/destination/internal/amplitude_http_client.go
+++ b/amplitude/plugins/destination/internal/amplitude_http_client.go
@@ -109,6 +109,9 @@ func (c *amplitudeHTTPClient) Send(payload AmplitudePayload) AmplitudeResponse {
 	var amplitudeResponse AmplitudeResponse
 	if json.Valid(body) {
 		_ = json.Unmarshal(body, &amplitudeResponse)
+	}else{
+		c.logger.Debugf("HTTP response body is not valid JSON: %s", string(body))
+		amplitudeResponse.Code = response.StatusCode
 	}
 
 	amplitudeResponse.Status = response.StatusCode


### PR DESCRIPTION
<!---
Thanks for contributing to the Amplitude Go repository! 🎉

Please fill out the following sections to help us quickly review your pull request.
--->

### Summary

[AMP-100974]

The SDK took the assumption that all response bodies were json format `{code: xxx, }` and used `json.Unmarshal(body, &amplitudeResponse)` to generate a `AmplitudeResponse` based on the response body. 

The error happens when the response body is non-json format, for example, when 413
```
// response body
<html>
<head><title>413 Request Entity Too Large</title></head>
<body>
<center><h1>413 Request Entity Too Large</h1></center>
<hr><center>nginx</center>
</body>
</html>
```
`AmplitudeResponse.Code` is not assigned and defaults to 0. In result It will not go into `reduceChunkSize()`. And the batch size will never be reduced and the bad event will never be dropped.

This PR adds the else condition when response body is not json format and assign `response.StatusCode` as`amplitudeResponse.Code`.



### Checklist

* [ ] Does your PR title have the correct [title format](https://github.com/amplitude/analytics-go/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  <!-- Yes or no -->


[AMP-100974]: https://amplitude.atlassian.net/browse/AMP-100974?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ