### PR TITLE
fix: Override Code:0 with the StatusCode value

### DIFF
--- a/amplitude/plugins/destination/internal/amplitude_http_client.go
+++ b/amplitude/plugins/destination/internal/amplitude_http_client.go
@@ -111,7 +111,6 @@ func (c *amplitudeHTTPClient) Send(payload AmplitudePayload) AmplitudeResponse {
 		_ = json.Unmarshal(body, &amplitudeResponse)
 	} else {
 		c.logger.Debugf("HTTP response body is not valid JSON: %s", string(body))
-		amplitudeResponse.Code = response.StatusCode
 	}
 
 	amplitudeResponse.Status = response.StatusCode

--- a/amplitude/plugins/destination/internal/amplitude_http_client_test.go
+++ b/amplitude/plugins/destination/internal/amplitude_http_client_test.go
@@ -122,7 +122,7 @@ func (t *AmplitudeHTTPClientSuiteSuite) TestSend_Empty() {
 
 func (t *AmplitudeHTTPClientSuiteSuite) TestSend_Timeout() {
 	timeout := time.Millisecond * 100
-	server := t.createTestServer(timeout * 2, 200, `{"code": 234, "error": "some server error"}`)
+	server := t.createTestServer(timeout*2, 200, `{"code": 234, "error": "some server error"}`)
 
 	client := internal.NewAmplitudeHTTPClient(
 		server.URL,
@@ -172,7 +172,9 @@ func (t *AmplitudeHTTPClientSuiteSuite) TestSend_NonJsonResponse() {
 
 	t.Require().Equal(internal.AmplitudeResponse{
 		Status: 413,
-		Code:   413,
+		// amplitude_http_client always returns Code:0
+		// if response body cannot be parsed (not json).
+		Code: 0,
 	}, response)
 
 	server.Close()

--- a/amplitude/plugins/destination/internal/amplitude_response.go
+++ b/amplitude/plugins/destination/internal/amplitude_response.go
@@ -7,10 +7,14 @@ import (
 )
 
 type AmplitudeResponse struct {
-	Status int   `json:"-"`
-	Err    error `json:"-"`
+	// An HTTP Response Code
+	Status int `json:"-"`
+	// An HTTP Response Err
+	Err error `json:"-"`
 
-	Code  int    `json:"code"`
+	// Code from the Response Body json
+	Code int `json:"code"`
+	// Error from the Response Body json
 	Error string `json:"error"`
 
 	MissingField               string           `json:"missing_field"`

--- a/amplitude/plugins/destination/internal/amplitude_response_processor.go
+++ b/amplitude/plugins/destination/internal/amplitude_response_processor.go
@@ -44,6 +44,10 @@ type amplitudeResponseProcessor struct {
 func (p *amplitudeResponseProcessor) Process(events []*types.StorageEvent, response AmplitudeResponse) AmplitudeProcessorResult {
 	responseStatus := response.normalizedStatus()
 
+	if response.Code == 0 {
+		response.Code = responseStatus
+	}
+
 	var urlErr *url.Error
 	isURLErr := errors.As(response.Err, &urlErr)
 


### PR DESCRIPTION
<!---
Thanks for contributing to the Amplitude Go repository! 🎉

Please fill out the following sections to help us quickly review your pull request.
--->

### Summary

<!-- What does the PR do? -->

The Amplitude client is setup like the following:
```
amplitude.Client
    -> destination.amplitudePlugin
        -> storages.inMemoryEventStorage
        -> internal.AmplitudeHTTPClient
        -> internal.AmplitudeResponseProcessor
```

The flow works like the following:
1. Clients call `amplitude.Client.Track()` to send an event.
2. The event is added to `storages.inMemoryEventStorage` (by `destination.amplitudePlugin`)
3. Then, `destination.amplitudePlugin` pulls the events from the store asynchronously and sends them to Amplitude (server) via `internal.AmplitudeHTTPClient.Send()`
4. After, `destination.amplitudePlugin` waits for the http response and calls `internal.AmplitudeResponseProcessor.Process()` to transform the response from `AmplitudeResponse` to `AmplitudeProcessorResult`
5. And finally, `AmplitudeProcessorResult` is used to create `types.ExecuteResult` and call the client's callback

`AmplitudeResponse` has 2 status codes and 2 errors:

```
type AmplitudeResponse struct {
    Status int `json:"-"`            // An HTTP Response Code
    Err error `json:"-"`              // An HTTP Response Err

    Code int `json:"code"`        // Code from the Response Body json
    Error string `json:"error"`.  // Error from the Response Body json
    ...
}
```

`Code` field is populated from the json response body.
For example: 
```
{
  "code": 200,
  "events_ingested": 50,
  "payload_size_bytes": 50,
  "server_upload_time": 1396381378123
}
```
See: https://amplitude.com/docs/apis/analytics/batch-event-upload#successsummary

---

**Q: What happens if the http request failed, there's no response body or the body is not json?**

`Code` will be 0.

This leads to many issues:

One.
https://github.com/amplitude/analytics-go/pull/64 - a fix, which only takes care of 413

Two.
Customers get `Code=0` via the callback.
When this happens the customers don't know how to handle it.
Does it mean we should retry or drop the message?
This leads to a potential data loss.

A few examples of errors:
* `Event reached max retry times 1: code=0, events=...`
* `HTTP request failed: Post "https://api2.amplitude.com/batch": unexpected EOF: code=0, events=...`

---

In this change we make `internal.AmplitudeResponseProcessor` to assign `Code` from `StatusCode` (effectively http response status code) if `Code=0` (if request failed or json parsing failed).

This will tell the customer the real reason of a failure and the customer will be able to decide what to do with the message.

### Testing
* new unit tests

### Checklist

* [x] Does your PR title have the correct [title format](https://github.com/amplitude/analytics-go/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  <!-- Yes or no -->
