### PR TITLE
feat: Support of the user_agent property for the EventOptions

### DIFF
--- a/amplitude/types/event_options.go
+++ b/amplitude/types/event_options.go
@@ -7,6 +7,7 @@ import (
 type EventOptions struct {
 	UserID             string             `json:"user_id,omitempty"`
 	DeviceID           string             `json:"device_id,omitempty"`
+	UserAgent          string             `json:"user_agent,omitempty"`
 	Time               int64              `json:"time,omitempty"`
 	InsertID           string             `json:"insert_id,omitempty"`
 	Library            string             `json:"library,omitempty"`

--- a/amplitude/types/event_options_test.go
+++ b/amplitude/types/event_options_test.go
@@ -21,6 +21,7 @@ func (t *EventOptionsSuite) TestClone() {
 	original := types.EventOptions{
 		UserID:      "my-user",
 		DeviceID:    "my-device",
+		UserAgent:   "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7)",
 		Time:        123,
 		LocationLat: 5.67,
 		Plan: &types.Plan{
@@ -48,4 +49,23 @@ func (t *EventOptionsSuite) TestSetTime() {
 
 	require := t.Require()
 	require.Equal(int64(1668258855000), options.Time)
+}
+
+func (t *EventOptionsSuite) TestUserAgent() {
+	options := types.EventOptions{}
+
+	// Test setting UserAgent
+	userAgent := "Mozilla/5.0 (iPhone; CPU iPhone OS 15_0 like Mac OS X) AppleWebKit/605.1.15"
+	options.UserAgent = userAgent
+
+	require := t.Require()
+	require.Equal(userAgent, options.UserAgent)
+
+	// Test UserAgent in clone
+	cloned := options.Clone()
+	require.Equal(userAgent, cloned.UserAgent)
+
+	// Test empty UserAgent
+	emptyOptions := types.EventOptions{}
+	require.Empty(emptyOptions.UserAgent)
 }


### PR DESCRIPTION
<!---
Thanks for contributing to the Amplitude Go repository! 🎉

Please fill out the following sections to help us quickly review your pull request.
--->

### Summary

<!-- What does the PR do? -->
This PR adds a new `UserAgent` field to the `EventOptions` struct to support capturing user agent information for events sent from the server side.


### Checklist

* [x] Does your PR title have the correct [title format](https://github.com/amplitude/analytics-go/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)? **YES**
* [x] Does your PR have a breaking change?  **NO**
